### PR TITLE
Adiciona task para rodar modelos alterados + refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ $ pip install dbteasy
 $ dbteasy --version
 ```
 
+You can also build the lib locally using `pip install -e .`.
+
 ## Main commands
 
 ```shell

--- a/dbteasy/tasks.py
+++ b/dbteasy/tasks.py
@@ -1,20 +1,16 @@
+from typing import List
+
 from invoke import task
-import subprocess
+from utils import (
+    get_changed_models,
+    get_modified_files,
+    extract_only_model_names,
+    bcolors,
+)
+
 import logging
 
 logging.getLogger().setLevel(logging.INFO)
-
-
-class bcolors:
-    HEADER = "\033[95m"
-    OKBLUE = "\033[94m"
-    OKCYAN = "\033[96m"
-    OKGREEN = "\033[92m"
-    WARNING = "\033[93m"
-    FAIL = "\033[91m"
-    ENDC = "\033[0m"
-    BOLD = "\033[1m"
-    UNDERLINE = "\033[4m"
 
 
 @task
@@ -82,34 +78,21 @@ def docs(c):
 @task
 def run_changed(c, compare_branch=""):
     """
-    Capture modified sql files from models using git diff (n_models) against current branch or, 
+    Capture modified sql files from models using git diff (n_models) against current branch or,
     optionally, againts another branch defined by the argument 'compare_branch'.
 
     It runs `dbt run --models (n_models)`.
     """
-    if compare_branch == "":
-        print(f"Capturing modified sql files from models against current branch...")
-    else:
-        print(f"Capturing modified sql files from models against {compare_branch} branch...")
-    models_diff_result = (
-        subprocess.Popen(
-            f"git diff --name-only {compare_branch}| grep '\.sql'$",
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        .communicate()[0]
-        .decode("utf-8")
-    )
-    models_diff_list = models_diff_result.split("\n")
-    models_diff_list = [model for model in models_diff_list if model != ""]
-    if len(models_diff_list) > 0:
-        result_model_list = []
-        for model in models_diff_list:
-            model_name = model.split("/")[-1].split(".")[0]
-            result_model_list.append(model_name)
-        result_models = " ".join(result_model_list)
-        print(bcolors.OKBLUE + f"Models changed: {result_models}" + bcolors.OKBLUE)
-        c.run("dbt run --models {}".format(result_models))
-    else:
-        print(bcolors.OKBLUE + f"No models changed" + bcolors.OKBLUE)
+    changed_models: List[str] = get_changed_models(compare_branch)
+    if changed_models:
+        c.run("dbt run --models {}".format(" ".join(changed_models)))
+
+
+@task
+def test_changed(c, compare_branch=""):
+    """
+    Test modified models against current branch or, optionally,
+    againts another branch defined by the argument 'compare_branch'.
+    """
+    changed_models: List[str] = get_changed_models(compare_branch)
+    c.run("dbt run --models {}".format(changed_models))

--- a/dbteasy/tasks.py
+++ b/dbteasy/tasks.py
@@ -80,13 +80,20 @@ def docs(c):
 
 
 @task
-def run_changed(c):
+def run_changed(c, compare_branch=""):
     """
-    Capture modified sql files from models using git diff (n_models). Run dbt run --models (n_models).
+    Capture modified sql files from models using git diff (n_models) against current branch or, 
+    optionally, againts another branch defined by the argument 'compare_branch'.
+
+    It runs `dbt run --models (n_models)`.
     """
+    if compare_branch == "":
+        print(f"Capturing modified sql files from models against current branch...")
+    else:
+        print(f"Capturing modified sql files from models against {compare_branch} branch...")
     models_diff_result = (
         subprocess.Popen(
-            "git diff --name-only | grep '\.sql'$",
+            f"git diff --name-only {compare_branch}| grep '\.sql'$",
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/dbteasy/tasks.py
+++ b/dbteasy/tasks.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from invoke import task
-from utils import (
+from dbteasy.utils import (
     get_changed_models,
     get_modified_files,
     extract_only_model_names,
@@ -95,4 +95,4 @@ def test_changed(c, compare_branch=""):
     againts another branch defined by the argument 'compare_branch'.
     """
     changed_models: List[str] = get_changed_models(compare_branch)
-    c.run("dbt run --models {}".format(changed_models))
+    c.run("dbt test --models {}".format(" ".join(changed_models)))

--- a/dbteasy/utils.py
+++ b/dbteasy/utils.py
@@ -1,0 +1,62 @@
+from typing import List
+import subprocess
+
+
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
+def get_modified_files(compare_branch: str = "") -> List[str]:
+    """
+    Returns a list of files that have been modified in the given branch.
+    """
+    compare_branch_string = f"{compare_branch}" if compare_branch else "current"
+    print(
+        f"Capturing modified sql files from models against {compare_branch_string} branch..."
+    )
+    modified_files: List[str] = (
+        subprocess.Popen(
+            f"git diff --name-only {compare_branch}",
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        .communicate()[0]
+        .decode("utf-8")
+        .split("\n")
+    )
+    modified_files = [model for model in modified_files if model != ""]
+    return modified_files
+
+
+def extract_only_model_names(model_paths: List[str]) -> List[str]:
+    """
+    Extracts the model name from a file name.
+    """
+    model_names = []
+    for model in model_paths:
+        model_name = model.split("/")[-1].split(".")[0]
+        model_names.append(model_name)
+    return model_names
+
+
+def get_changed_models(compare_branch: str = "") -> List[str]:
+    """
+    Returns a list of models that have been modified in the given branch.
+    """
+    modified_files: List[str] = get_modified_files(compare_branch)
+    changed_models: List[str] = extract_only_model_names(modified_files)
+    if modified_files:
+        models_string = "\n".join(changed_models)
+        print(bcolors.OKBLUE + f"Models changed: {models_string}" + bcolors.OKBLUE)
+    else:
+        print(bcolors.OKBLUE + f"No models changed" + bcolors.OKBLUE)
+    return changed_models

--- a/dbteasy/utils.py
+++ b/dbteasy/utils.py
@@ -55,8 +55,8 @@ def get_changed_models(compare_branch: str = "") -> List[str]:
     modified_files: List[str] = get_modified_files(compare_branch)
     changed_models: List[str] = extract_only_model_names(modified_files)
     if modified_files:
-        models_string = "\n".join(changed_models)
-        print(bcolors.OKBLUE + f"Models changed: {models_string}" + bcolors.OKBLUE)
+        models_string = "\n\t".join(changed_models)
+        print(bcolors.OKBLUE + f"Models changed:\n\t{models_string}" + bcolors.OKBLUE)
     else:
         print(bcolors.OKBLUE + f"No models changed" + bcolors.OKBLUE)
     return changed_models

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="dbteasy",
-    version="0.2.6",
+    version="0.3.0",
     author="Arthur Morais",
     author_email="arthurfmmorais@gmail.com",
     description="A small package to simplify the use of dbt core",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
     py_modules=["dbteasy"],
     python_requires=">=3.9",
     packages=setuptools.find_packages(),
-    install_requires=["invoke==1.7.1", "dbt-core==1.1.0"],
+    install_requires=["invoke==1.7.1"],
     entry_points={"console_scripts": ["dbteasy = dbteasy.main:program.run"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     py_modules=["dbteasy"],
-    python_requires=">=3.9.13",
+    python_requires=">=3.9",
     packages=setuptools.find_packages(),
-    install_requires=["invoke==1.7.1"],
+    install_requires=["invoke==1.7.1", "dbt-core==1.1.0"],
     entry_points={"console_scripts": ["dbteasy = dbteasy.main:program.run"]},
 )


### PR DESCRIPTION
Nesse PR estou sugerindo a adição de uma task para o usuário rodar teste de modelos que foram alterados em relação a uma dada branch. 

Mudanças:
- [x] abstrai funções utilitárias no arquivo `utils.py`, que são usados tanto pelo `run_changed` existente como pelo novo `test_changed` inserido em `tasks.py`
- [x]  adiciona a task `test_changed` para rodar modelos que foram alterados
- [x] update no readme 

Aqui, estou usando ideias que já tinha colocado no #1 , então seria melhor avaliar este último PR também e ver se é interessante para o projeto.